### PR TITLE
Expose GetObject to API users

### DIFF
--- a/pivman.go
+++ b/pivman.go
@@ -95,7 +95,7 @@ func (y Yubikey) deriveManagementKey() ([]byte, error) {
 func (y Yubikey) getPIVMANAttributes() (map[int][]byte, error) {
 	attributes := map[int][]byte{}
 
-	bytes, err := y.getObject(pivmanObjData)
+	bytes, err := y.GetObject(pivmanObjData)
 	if err != nil {
 		return nil, err
 	}

--- a/slot.go
+++ b/slot.go
@@ -30,7 +30,6 @@ import "C"
 
 import (
 	"fmt"
-	"unsafe"
 
 	"encoding/asn1"
 
@@ -181,7 +180,7 @@ func (y Slot) getAlgorithm() (C.uchar, error) {
 
 // Get the x509.Certificate stored in the PIV Slot off the chip
 func (y Slot) GetCertificate() (*x509.Certificate, error) {
-	bytes, err := y.yubikey.getObject(int(y.Id.Certificate))
+	bytes, err := y.yubikey.GetObject(int(y.Id.Certificate))
 	if err != nil {
 		return nil, err
 	}
@@ -209,15 +208,7 @@ func (y *Slot) Update(cert x509.Certificate) error {
 		return err
 	}
 
-	cCertDer := (*C.uchar)(C.CBytes(certDer))
-	cCertDerLen := C.size_t(len(certDer))
-	defer C.free(unsafe.Pointer(cCertDer))
-
-	if err := getError(C.ykpiv_save_object(
-		y.yubikey.state,
-		C.int(y.Id.Certificate),
-		cCertDer, cCertDerLen,
-	), "save_object"); err != nil {
+	if err := y.yubikey.SaveObject(y.Id.Certificate, certDer); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This was hidden before because it may result in a low-level detail
being exposed, but upon further thought, this is a sane and reasonable
function to expose.

To add API symmetry, a SaveObject function was added to write data back
to the token. The only method calling the underlying ykpiv function,
`ykpiv_save_object`, Slot.Update, has been refactored to use SaveObject.

Callers should be careful to not write things they shouldn't write in
places they shouldn't write things. Advice for life, really.