### PR TITLE
Refactor Update to have a general SaveCertificate helper

### DIFF
--- a/slot.go
+++ b/slot.go
@@ -31,8 +31,6 @@ import "C"
 import (
 	"fmt"
 
-	"encoding/asn1"
-
 	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
@@ -199,16 +197,7 @@ func (y Slot) GetCertificate() (*x509.Certificate, error) {
 
 // Write the x509 Certificate to the Yubikey.
 func (y *Slot) Update(cert x509.Certificate) error {
-	certDer, err := bytearray.Encode([]asn1.RawValue{
-		asn1.RawValue{Tag: 0x10, IsCompound: true, Class: 0x01, Bytes: cert.Raw},
-		asn1.RawValue{Tag: 0x11, IsCompound: true, Class: 0x01, Bytes: []byte{0x00}},
-		asn1.RawValue{Tag: 0x1E, IsCompound: true, Class: 0x03, Bytes: []byte{}},
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := y.yubikey.SaveObject(y.Id.Certificate, certDer); err != nil {
+	if err := y.yubikey.SaveCertificate(y.Id, cert); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is helpful if you've created a private key on the Yubikey, signed a
CSR, but have *not* written the Certificate back in before you lost the
Slot. This will allow you to write the Certificate without having to
load the Certificate, which would throw a GeneralError out of ykpiv.so