### PR TITLE
Move GetCertificate to Yubikey

### DIFF
--- a/slot.go
+++ b/slot.go
@@ -34,8 +34,6 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
-
-	"pault.ag/go/ykpiv/internal/bytearray"
 )
 
 // SlotId encapsulates the Identifiers required to preform key operations
@@ -178,21 +176,7 @@ func (y Slot) getAlgorithm() (C.uchar, error) {
 
 // Get the x509.Certificate stored in the PIV Slot off the chip
 func (y Slot) GetCertificate() (*x509.Certificate, error) {
-	bytes, err := y.yubikey.GetObject(int(y.Id.Certificate))
-	if err != nil {
-		return nil, err
-	}
-
-	objects, err := bytearray.Decode(bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(objects) != 3 {
-		return nil, fmt.Errorf("ykpiv: GetCertificate: We expected two der byte arrays from the key")
-	}
-
-	return x509.ParseCertificate(objects[0].Bytes)
+	return y.yubikey.GetCertificate(y.Id)
 }
 
 // Write the x509 Certificate to the Yubikey.

--- a/ykpiv.go
+++ b/ykpiv.go
@@ -394,6 +394,24 @@ func (y Yubikey) SaveCertificate(slotId SlotId, cert x509.Certificate) error {
 	return y.SaveObject(slotId.Certificate, certDer)
 }
 
+func (y Yubikey) GetCertificate(slotId SlotId) (*x509.Certificate, error) {
+	bytes, err := y.GetObject(int(slotId.Certificate))
+	if err != nil {
+		return nil, err
+	}
+
+	objects, err := bytearray.Decode(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(objects) != 3 {
+		return nil, fmt.Errorf("ykpiv: GetCertificate: We expected two der byte arrays from the key")
+	}
+
+	return x509.ParseCertificate(objects[0].Bytes)
+}
+
 // Create a new Yubikey.
 //
 // This will use the options in the given `ykpiv.Options` struct to


### PR DESCRIPTION
This refactor allows getting a Certificate without having to go through
hoops to try and load the Slot. The Slot GetCertificate method remains
intact, and calls the Yubikey's method with the Slot's Id