### PR TITLE
Bugfix to Library Path (Mac)

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -21,7 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/bin -lykpiv
+#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
 #cgo linux CFLAGS: -I/usr/include/ykpiv/

--- a/errors.go
+++ b/errors.go
@@ -21,7 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/bin -lykpiv
+#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
 #cgo linux CFLAGS: -I/usr/include/ykpiv/

--- a/generate.go
+++ b/generate.go
@@ -21,7 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/bin -lykpiv
+#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
 #cgo linux CFLAGS: -I/usr/include/ykpiv/

--- a/pivman.go
+++ b/pivman.go
@@ -21,7 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/bin -lykpiv
+#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
 #cgo linux CFLAGS: -I/usr/include/ykpiv/

--- a/sign.go
+++ b/sign.go
@@ -21,7 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/bin -lykpiv
+#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
 #cgo linux CFLAGS: -I/usr/include/ykpiv/

--- a/slot.go
+++ b/slot.go
@@ -21,7 +21,7 @@
 package ykpiv
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/bin -lykpiv
+#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
 #cgo linux CFLAGS: -I/usr/include/ykpiv/

--- a/ykpiv.go
+++ b/ykpiv.go
@@ -24,7 +24,7 @@ package ykpiv
 //      when I build it. For now this will keep it quiet :\
 
 /*
-#cgo darwin LDFLAGS: -L /usr/local/bin -lykpiv
+#cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv -Wl,--allow-multiple-definition
 #cgo linux CFLAGS: -I/usr/include/ykpiv/


### PR DESCRIPTION
Sorry! I did a typo. Of course the library path is /usr/local/lib and not /usr/local/bin. Bit strange, that this worked on my computer... (i think because of go-work/pkg/darwin_amd64/pault.ag/go/ykpiv.a).