### PR TITLE
Add support for specifying pin/touch policy on generated keys.

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -39,6 +39,8 @@ import (
 	"crypto/rsa"
 
 	"pault.ag/go/ykpiv/internal/bytearray"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 )
 
 type TouchPolicy byte
@@ -92,11 +94,43 @@ func decodeYubikeyRSAPublicKey(der []byte) (*rsa.PublicKey, error) {
 	return &pubKey, nil
 }
 
+func decodeYubikeyECPublicKey(curve elliptic.Curve, der []byte) (*ecdsa.PublicKey, error) {
+	byteArray, err := bytearray.DERDecode(der)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(byteArray) != 1 {
+		return nil, fmt.Errorf("ykpiv: decodeYubikeyECPublicKey: Byte Array isn't length 1")
+	}
+
+	publicPointSpec := byteArray[0].Bytes
+	if publicPointSpec[0] != 0x04 {
+		return nil, fmt.Errorf("ykpiv: decodeYubikeyECPublicKey: EC public point byte != 4: %d", publicPointSpec[0])
+	}
+
+	pointLen := (curve.Params().BitSize+7)/8
+	if len(publicPointSpec) != 2 * pointLen + 1 {
+		return nil, fmt.Errorf("ykpiv: decodeYubikeyECPublicKey: EC public point bytes wrong length; %d", len(publicPointSpec))
+	}
+
+	x := new(big.Int)
+	x.SetBytes(publicPointSpec[1:1+pointLen])
+	y := new(big.Int)
+	y.SetBytes(publicPointSpec[1+pointLen:1+2*pointLen])
+
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X: x,
+		Y: y,
+	}, nil
+}
+
 // Generate an RSA Keypair in slot `id` (using a modulus size of `bits`),
 // and construct a Certificate-less Slot. This Slot can not be recovered
 // later, so it should be used to sign a CSR or Self-Signed Certificate
 // before we lose the key material.
-func (y Yubikey) GenerateRSA(id SlotId, bits int, pinPolicy PinPolicy, touchPolicy TouchPolicy) (*Slot, error) {
+func (y Yubikey) GenerateRSA(id SlotId, bits int) (*Slot, error) {
 	return y.GenerateRSAWithPolicies(id, bits, PinPolicyNull, TouchPolicyNull)
 }
 
@@ -133,6 +167,33 @@ func (y Yubikey) generateRSAKey(slot SlotId, bits int, pinPolicy PinPolicy, touc
 	}
 
 	return decodeYubikeyRSAPublicKey(der)
+}
+
+func (y Yubikey) GenerateECKey(slot SlotId, bits int, pinPolicy PinPolicy, touchPolicy TouchPolicy) (*Slot, error) {
+
+	var curve elliptic.Curve
+	var algorithm byte
+	switch bits {
+	case 256:
+		curve = elliptic.P256()
+		algorithm = C.YKPIV_ALGO_ECCP256
+	case 384:
+		curve = elliptic.P384()
+		algorithm = C.YKPIV_ALGO_ECCP384
+	default:
+		return nil, fmt.Errorf("ykpiv: GenerateECKey: Unknown bit size: %d", bits)
+	}
+
+	der, err := y.generateKey(slot, algorithm, pinPolicy, touchPolicy)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey, err := decodeYubikeyECPublicKey(curve, der)
+	if err != nil {
+		return nil, err
+	}
+	return &Slot{yubikey: y, Id: slot, PublicKey: pubKey}, nil
 }
 
 // This is a low-level binding into the underlying instruction to actually

--- a/sign.go
+++ b/sign.go
@@ -48,6 +48,9 @@ import (
 // about the digest and the OID, we can just prefix the digest with some ASN.1
 // fresh off the CPU
 var hashOIDs = map[crypto.Hash][]byte{
+	crypto.SHA1: {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02,
+		0x1a, 0x05, 0x00, 0x04, 0x14},
+
 	crypto.SHA224: {0x30, 0x2d, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
 		0x65, 0x03, 0x04, 0x02, 0x04, 0x05, 0x00, 0x04, 0x1c},
 
@@ -66,8 +69,30 @@ var hashOIDs = map[crypto.Hash][]byte{
 // Unlike other Sign implementations, `rand` will be completely discarded in
 // favor of the on-chip RNG.
 //
-// The output will be a PKCS#1 v1.5 signature over the digest.
+// The output will be a PKCS#1 v1.5 signature (for RSA) or ECDSA signature (for EC keys) over the digest.
 func (s Slot) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	algorithm, err := s.getAlgorithm()
+	if err != nil {
+		return nil, err
+	}
+
+	switch algorithm {
+	case C.YKPIV_ALGO_RSA1024:
+		return s.signRsa(digest, opts, algorithm)
+	case C.YKPIV_ALGO_RSA2048:
+		return s.signRsa(digest, opts, algorithm)
+	case C.YKPIV_ALGO_ECCP256:
+		return s.signEcdsa(digest, opts, algorithm)
+	case C.YKPIV_ALGO_ECCP384:
+		return s.signEcdsa(digest, opts, algorithm)
+	default:
+		return nil, fmt.Errorf("ykpiv: Sign: Unsupported algorithm")
+	}
+
+}
+
+func (s Slot) signRsa(digest []byte, opts crypto.SignerOpts, algorithm C.uchar) ([]byte, error) {
+
 	hash := opts.HashFunc()
 	if len(digest) != hash.Size() {
 		return nil, fmt.Errorf("ykpiv: Sign: Digest length doesn't match passed crypto algorithm")
@@ -79,11 +104,6 @@ func (s Slot) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, 
 	}
 	digest = append(prefix, digest...)
 
-	algorithm, err := s.getAlgorithm()
-	if err != nil {
-		return nil, err
-	}
-
 	var computedDigest []byte
 	switch algorithm {
 	case C.YKPIV_ALGO_RSA1024:
@@ -92,6 +112,47 @@ func (s Slot) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, 
 		computedDigest = pkcs1v15.Pad(digest, 256)
 	default:
 		return nil, fmt.Errorf("ykpiv: Sign: Can't preform padding for signature, unknown algorithm")
+	}
+
+	var cDigestLen = C.size_t(len(computedDigest))
+	var cDigest = (*C.uchar)(C.CBytes(computedDigest))
+	defer C.free(unsafe.Pointer(cDigest))
+
+	var cSignatureLen = C.size_t(1024)
+	var cSignature = (*C.uchar)(C.malloc(cSignatureLen))
+	defer C.free(unsafe.Pointer(cSignature))
+
+	if err := getError(C.ykpiv_sign_data(
+		s.yubikey.state,
+		cDigest, cDigestLen,
+		cSignature, &cSignatureLen,
+
+		algorithm,
+		C.uchar(s.Id.Key),
+	), "sign_data"); err != nil {
+		return nil, err
+	}
+
+	return C.GoBytes(unsafe.Pointer(cSignature), C.int(cSignatureLen)), nil
+}
+
+func (s Slot) signEcdsa(digest []byte, opts crypto.SignerOpts, algorithm C.uchar) ([]byte, error) {
+
+	var curveSizeBytes int
+	switch algorithm {
+	case C.YKPIV_ALGO_ECCP256:
+		curveSizeBytes = 32
+	case C.YKPIV_ALGO_ECCP384:
+		curveSizeBytes = 48
+	default:
+		return nil, fmt.Errorf("ykpiv: Sign: Can't perform ECDSA signature, unknown algorithm")
+	}
+
+	var computedDigest []byte
+	if len(digest) > curveSizeBytes {
+		computedDigest = digest[:curveSizeBytes]
+	} else {
+		computedDigest = digest
 	}
 
 	var cDigestLen = C.size_t(len(computedDigest))

--- a/slot.go
+++ b/slot.go
@@ -36,6 +36,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/ecdsa"
 )
 
 // SlotId encapsulates the Identifiers required to preform key operations
@@ -170,6 +171,16 @@ func (y Slot) getAlgorithm() (C.uchar, error) {
 			return C.YKPIV_ALGO_RSA2048, nil
 		default:
 			return C.uchar(0), fmt.Errorf("ykpiv: getAlgorithm: Unknown RSA Modulus size")
+		}
+	case *ecdsa.PublicKey:
+		ecPub := pubKey.(*ecdsa.PublicKey)
+		switch ecPub.Params().BitSize {
+		case 256:
+			return C.YKPIV_ALGO_ECCP256, nil
+		case 384:
+			return C.YKPIV_ALGO_ECCP384, nil
+		default:
+			return C.uchar(0), fmt.Errorf("ykpiv: getAlgorithm: Unknown ECDSA curive size")
 		}
 	default:
 		return C.uchar(0), fmt.Errorf("ykpiv: getAlgorithm: Unknown public key algorithm")


### PR DESCRIPTION
E.g. `slot, err := yk.GenerateRSAWithPolicies(ykpiv.Authentication, 2048, ykpiv.PinPolicyAlways, ykpiv.TouchPolicyAlways)`