### PR TITLE
Add support for attestation

### DIFF
--- a/slot.go
+++ b/slot.go
@@ -34,9 +34,9 @@ import (
 	"fmt"
 
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
-	"crypto/ecdsa"
 )
 
 // SlotId encapsulates the Identifiers required to preform key operations
@@ -91,6 +91,16 @@ var (
 		Certificate: C.YKPIV_OBJ_KEY_MANAGEMENT,
 		Key:         C.YKPIV_KEY_KEYMGM,
 		Name:        "Key Management",
+	}
+
+	// Attestation, which contains a certificate issued by the Yubico CA
+	// and can be used to attest keys generated in the other slots.
+	// Requires YubiKey 4.3 or later.
+	// NB: if this key or cert is overwritten it cannot be brought back!
+	Attestation SlotId = SlotId{
+		Certificate: C.YKPIV_OBJ_ATTESTATION,
+		Key:         C.YKPIV_KEY_ATTESTATION,
+		Name:        "Attestation",
 	}
 )
 
@@ -185,6 +195,11 @@ func (y Slot) getAlgorithm() (C.uchar, error) {
 	default:
 		return C.uchar(0), fmt.Errorf("ykpiv: getAlgorithm: Unknown public key algorithm")
 	}
+}
+
+// Attest the key in this slot and get the attestation certificate
+func (y Slot) Attest() (*x509.Certificate, error) {
+	return y.yubikey.Attest(y.Id)
 }
 
 // Get the x509.Certificate stored in the PIV Slot off the chip


### PR DESCRIPTION
Add an Attest() function and Attestation slot ID values (to be passed to
GetCertificate for exporting the attestation cert). Supported as of YubiKey 4.3.

I don't add support to check that the YubiKey version inserted is at least 4.3;
and do not take any steps to prevent the user from clobbering the attestation
key or cert, as the YubiKey utilities take no such measures either.