### PR TITLE
Added /usr/local/include/ykpiv to CGO include path for Linux

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -24,7 +24,7 @@ package ykpiv
 #cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo linux CFLAGS: -I/usr/local/include/ykpiv/ -I/usr/include/ykpiv/
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/errors.go
+++ b/errors.go
@@ -24,7 +24,7 @@ package ykpiv
 #cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo linux CFLAGS: -I/usr/local/include/ykpiv/ -I/usr/include/ykpiv/
 #include <ykpiv.h>
 */
 import "C"

--- a/generate.go
+++ b/generate.go
@@ -24,7 +24,7 @@ package ykpiv
 #cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo linux CFLAGS: -I/usr/local/include/ykpiv/ -I/usr/include/ykpiv/
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/pivman.go
+++ b/pivman.go
@@ -24,7 +24,7 @@ package ykpiv
 #cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo linux CFLAGS: -I/usr/local/include/ykpiv/ -I/usr/include/ykpiv/
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/sign.go
+++ b/sign.go
@@ -24,7 +24,7 @@ package ykpiv
 #cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo linux CFLAGS: -I/usr/local/include/ykpiv/ -I/usr/include/ykpiv/
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/slot.go
+++ b/slot.go
@@ -24,7 +24,7 @@ package ykpiv
 #cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo linux CFLAGS: -I/usr/local/include/ykpiv/ -I/usr/include/ykpiv/
 #include <ykpiv.h>
 #include <stdlib.h>
 */

--- a/ykpiv.go
+++ b/ykpiv.go
@@ -27,7 +27,7 @@ package ykpiv
 #cgo darwin LDFLAGS: -L /usr/local/lib -lykpiv
 #cgo darwin CFLAGS: -I/usr/local/include/ykpiv/
 #cgo linux LDFLAGS: -lykpiv -Wl,--allow-multiple-definition
-#cgo linux CFLAGS: -I/usr/include/ykpiv/
+#cgo linux CFLAGS: -I/usr/local/include/ykpiv/ -I/usr/include/ykpiv/
 #cgo windows CFLAGS: -I./win/include/ykpiv/
 #cgo windows LDFLAGS: ./win/lib/libykpiv.dll.a
 #include <ykpiv.h>


### PR DESCRIPTION
On Ubuntu Linux (and derivatives, like the Mint Linux I'm using) the bundled version of [yubico-piv-tool](https://developers.yubico.com/yubico-piv-tool/) is 1.4.2, and is incompatible with this Go library (also see #16).

This PR makes it possible to build the latest version of yubico-piv-tool and install it to `/usr/local`. Without this change to the CGO parameters, the headers wouldn't be found in `/usr/local/include/ykpiv`.

It's still necessary to ensure `/usr/local/lib` is mentioned in `/etc/ld.so.conf` for the linker to find the library.