### PR TITLE
Use the right type when calling ykpiv_get_serial (C.uint32_t vs C.uint)

### DIFF
--- a/ykpiv.go
+++ b/ykpiv.go
@@ -203,7 +203,7 @@ func (y Yubikey) Version() ([]byte, error) {
 }
 
 func (y Yubikey) Serial() (uint32, error) {
-	serial := C.uint(0)
+	serial := C.uint32_t(0)
 	if err := getError(C.ykpiv_get_serial(y.state, &serial), "get_serial"); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
When compiling under ARM, I run into an issue because `ykpiv_get_serial` is being called with the wrong type: `pault.ag/go/ykpiv/ykpiv.go:207: cannot use &serial (type *C.uint) as type *C.uint32_t in argument to func literal`
This PR fixes that issue by using the expected type (https://github.com/Yubico/yubico-piv-tool/blob/master/lib/ykpiv.h#L209).