### PR TITLE
Use attestation to get public key if certificate is not populated

### DIFF
--- a/cmd/ykls/ykls.go
+++ b/cmd/ykls/ykls.go
@@ -57,7 +57,7 @@ func main() {
 			ykpiv.KeyManagement,
 		} {
 			slot, err := token.Slot(slotId)
-			if err != nil {
+			if err != nil || slot.Certificate == nil {
 				continue
 			}
 			fmt.Printf("Slot %s: %s\n", slotId, slot.Certificate.Subject.CommonName)

--- a/docs/quirks.md
+++ b/docs/quirks.md
@@ -4,12 +4,13 @@ Qurks of ykpiv
 ykpiv.Yubikey.Slot
 ------------------
 
-Slots which have private keys backing them are unable to be loaded since the
-Certificate will fail to be read. This could be fixed by pulling the Public
-Key material for that slot, but I can't find any obvious way to do so, so
-the code only pulls Public Key material from the Certificate in the Slot.
+Slots which have private keys backing them but were not generated on the
+Yubikey are unable to be loaded unless a public certificate has already
+been set. If an attestation key exists, and an attestation certificate
+can be loaded for the slot, the public key will be available. These slots
+will however not have a valid x509 certificate available for authentication.
 
-Basically, the only way to get a Slot with a nill Certificate is to call
+Basically, the only way to get a Slot with a nil Certificate is to call
 the Generation code, where we are actually able to pull the Public Key
 material out, and allow for bootstrapping. The advisable workflow would be
 to generate the key, then sign a CSR to import the Certificate later

--- a/tls.go
+++ b/tls.go
@@ -36,6 +36,11 @@ func (slot Slot) TLSCertificate() tls.Certificate {
 		// Decrypt() method for EC keys.
 		privKey = struct{ crypto.Signer }{slot}
 	}
+	if slot.Certificate == nil {
+		return tls.Certificate{
+			PrivateKey: privKey,
+		}
+	}
 	return tls.Certificate{
 		Certificate: [][]byte{slot.Certificate.Raw},
 		PrivateKey:  privKey,


### PR DESCRIPTION
This fixes on quirk by introducing another :neutral_face: 
Allows for a slot with a private key generated on a Yubikey with firmware >= 4.3 to be used for signing even if a certificate has not been set. Requires that slots be checked for a valid certificate before being used for other purposes.

Could also be implemented as a new function such as `SingerSlot`, which would make no guarantees around certificates.